### PR TITLE
[codex] bound relay subscriptions

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -11,5 +11,14 @@
 		"lower": 86400,
 		"upper": 900
 	},
+	"resourceLimits": {
+		"defaultSubscriptionLimit": 500,
+		"maxSubscriptionLimit": 1000,
+		"maxSubscriptionsPerConnection": 32,
+		"maxConnectionsPerIp": 64,
+		"maxMessageBytes": 65536,
+		"idleTimeoutSeconds": 120,
+		"pingIntervalSeconds": 30
+	},
 	"allowedPublicKeys": []
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
 	"testEnvironment": "node",
 	"testMatch": ["**/src/**/*.test.[jt]s?(x)"],
 	"testPathIgnorePatterns": ["/node_modules/", "/dist/"],
+	"modulePathIgnorePatterns": ["/dist/"],
 	"coverageReporters": ["json", "lcov", "text", "html"],
 	"transformIgnorePatterns": ["dist/.+\\.js"]
 };

--- a/resources/data_providers/sqlite/migrations/003_event_tags.sql
+++ b/resources/data_providers/sqlite/migrations/003_event_tags.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS EventTag (
+	event_id TEXT NOT NULL,
+	name TEXT NOT NULL,
+	value TEXT NOT NULL,
+	position INTEGER NOT NULL,
+	PRIMARY KEY (event_id, position),
+	FOREIGN KEY (event_id) REFERENCES Event(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_tag_name_value_event_id ON EventTag(name, value, event_id);
+CREATE INDEX IF NOT EXISTS idx_event_tag_event_id_name ON EventTag(event_id, name);
+
+INSERT OR IGNORE INTO EventTag (event_id, name, value, position)
+SELECT
+	Event.id,
+	json_extract(tag.value, '$[0]') AS name,
+	json_extract(tag.value, '$[1]') AS value,
+	CAST(tag.key AS INTEGER) AS position
+FROM Event, json_each(Event.tags) AS tag
+WHERE json_type(tag.value) = 'array'
+	AND json_array_length(tag.value) >= 2
+	AND json_type(tag.value, '$[0]') = 'text'
+	AND json_type(tag.value, '$[1]') = 'text';

--- a/src/WebSocket.ts
+++ b/src/WebSocket.ts
@@ -3,10 +3,11 @@ import WebSocket from "ws";
 import { FiltersObject } from "./types/FiltersObject";
 import { Subscription } from "./types/Subscription";
 import { Event } from "./types/Event";
-import { EventKind, EventKindType } from "./types/EventKind";
+import { EventKind } from "./types/EventKind";
 import { filtersMatchEvent } from "./utils/filtersMatchEvent";
 import { DataProvider } from "./types/DataProvider";
 import { Configuration, StorageType } from "./types/Configuration";
+import { normalizeSubscriptionLimit, resolveResourceLimits } from "./utils/resourceLimits";
 
 import express from "express";
 import * as http from "http";
@@ -20,18 +21,29 @@ import packageJson from "../package.json";
 import EventTextHandler from "./business_logic/event/text";
 import EventDeletionHandler from "./business_logic/event/deletion";
 import EventInsertHandler from "./business_logic/event/insert";
-import getEventKindType from "./utils/getEventKindType";
+
+type ClientId = `${string}-${string}-${string}-${string}-${string}`;
+
+interface ClientState {
+	"ws": WebSocket;
+	"ip": string;
+	"isAlive": boolean;
+	"lastActivityAt": number;
+}
 
 (async () => {
 	const app = express();
 	const server = http.createServer(app);
+	const resourceLimits = resolveResourceLimits(configuration);
 
 	const wss = new WebSocket.Server({
-		server
+		"server": server,
+		"maxPayload": resourceLimits.maxMessageBytes
 	});
 
-	let clients: {[key: `${string}-${string}-${string}-${string}-${string}`]: any} = {};
-	let subscriptions: {[key: `${string}-${string}-${string}-${string}-${string}`]: Subscription[]} = {};
+	let clients: {[key: string]: ClientState} = {};
+	let subscriptions: {[key: string]: Subscription[]} = {};
+	let connectionCountsByIp: {[key: string]: number} = {};
 
 	const dataProvider: DataProvider = await (async () => {
 		const providerType: StorageType = configuration.storage.type;
@@ -101,6 +113,12 @@ import getEventKindType from "./utils/getEventKindType";
 				}
 				response.limitation["restricted_writes"] = true;
 			}
+			if (!response.limitation) {
+				response.limitation = {};
+			}
+			response.limitation["max_limit"] = resourceLimits.maxSubscriptionLimit;
+			response.limitation["max_message_length"] = resourceLimits.maxMessageBytes;
+			response.limitation["max_subscriptions"] = resourceLimits.maxSubscriptionsPerConnection;
 			res.json(response);
 		} else {
 			next();
@@ -112,26 +130,106 @@ import getEventKindType from "./utils/getEventKindType";
 			subscriptions.forEach((subscription: Subscription) => {
 				const filters = subscription.filters;
 				if (filtersMatchEvent(filters, event)) {
-					clients[uuid as `${string}-${string}-${string}-${string}-${string}`].send(JSON.stringify(["EVENT", subscription.id, event]));
+					const client = clients[uuid];
+					if (client && client.ws.readyState === WebSocket.OPEN) {
+						client.ws.send(JSON.stringify(["EVENT", subscription.id, event]));
+					}
 				}
 			});
 		});
 	}
 
-	wss.on("connection", (ws) => {
-		const uuid = randomUUID();
-		console.log(`Client connected: ${uuid}`);
+	/**
+	 * Sends a Nostr NOTICE if the connection can still receive messages.
+	 */
+	function sendNotice(ws: WebSocket, message: string): void {
+		if (ws.readyState === WebSocket.OPEN) {
+			ws.send(JSON.stringify(["NOTICE", message]));
+		}
+	}
 
-		clients[uuid] = ws;
+	/**
+	 * Releases all per-client resources and decrements the IP connection count.
+	 */
+	function cleanupClient(uuid: ClientId): void {
+		const client = clients[uuid];
+		if (!client) {
+			return;
+		}
+
+		connectionCountsByIp[client.ip] = Math.max((connectionCountsByIp[client.ip] ?? 1) - 1, 0);
+		if (connectionCountsByIp[client.ip] === 0) {
+			delete connectionCountsByIp[client.ip];
+		}
+
+		delete clients[uuid];
+		delete subscriptions[uuid];
+	}
+
+	/**
+	 * Extracts the best available remote IP for coarse connection limiting.
+	 */
+	function getConnectionIp(request: http.IncomingMessage): string {
+		const forwardedFor = request.headers["x-forwarded-for"];
+		if (typeof forwardedFor === "string" && forwardedFor.length > 0) {
+			return forwardedFor.split(",")[0].trim();
+		}
+
+		return request.socket.remoteAddress ?? "unknown";
+	}
+
+	wss.on("connection", (ws, request) => {
+		const ip = getConnectionIp(request);
+		if ((connectionCountsByIp[ip] ?? 0) >= resourceLimits.maxConnectionsPerIp) {
+			sendNotice(ws, "too many connections from this IP");
+			ws.close(1008, "too many connections");
+			console.warn("Rejected client connection", {
+				"ip": ip,
+				"maxConnectionsPerIp": resourceLimits.maxConnectionsPerIp
+			});
+			return;
+		}
+
+		const uuid = randomUUID() as ClientId;
+		connectionCountsByIp[ip] = (connectionCountsByIp[ip] ?? 0) + 1;
+		clients[uuid] = {
+			"ws": ws,
+			"ip": ip,
+			"isAlive": true,
+			"lastActivityAt": Date.now()
+		};
+		subscriptions[uuid] = [];
+		console.log("Client connected", {
+			"uuid": uuid,
+			"ip": ip,
+			"connectionCountForIp": connectionCountsByIp[ip]
+		});
 
 		ws.on("message", async (message: Buffer) => {
+			const client = clients[uuid];
+			if (!client) {
+				return;
+			}
+			client.lastActivityAt = Date.now();
+
+			if (message.length > resourceLimits.maxMessageBytes) {
+				sendNotice(ws, `message too large; max size is ${resourceLimits.maxMessageBytes} bytes`);
+				ws.close(1009, "message too large");
+				return;
+			}
+
 			const messageString: string = message.toString();
 			let messageObject: any;
 
 			try {
 				messageObject = JSON.parse(messageString);
 			} catch (e) {
-				console.error(`Received message that is not valid JSON: *${messageString}*`);
+				sendNotice(ws, "invalid: message is not valid JSON");
+				console.error("Received message that is not valid JSON", {
+					"uuid": uuid,
+					"ip": ip,
+					"byteLength": message.length
+				});
 				return;
 			}
 
@@ -153,7 +251,11 @@ import getEventKindType from "./utils/getEventKindType";
 							break;
 						default:
 							ws.send(JSON.stringify(["OK", message.id, false, "invalid: unsupported event kind"]));
-							console.error(`Received message with unsupported event kind`, message);
+							console.error("Received message with unsupported event kind", {
+								"id": message.id,
+								"kind": message.kind,
+								"pubkey": message.pubkey
+							});
 							break;
 					}
 
@@ -161,64 +263,80 @@ import getEventKindType from "./utils/getEventKindType";
 				}
 				case "REQ": {
 					const id = messageObject[1];
-					const filters: FiltersObject = messageObject[2];
-
-					subscriptions[uuid] = subscriptions[uuid] || [];
-					subscriptions[uuid].push({
-						"id": id,
-						"filters": filters
-					});
-
-					// Get all events matching the requested filters
-					const matchedEvents = (await dataProvider.events.getAll(filters)).filter((event: Event) => filtersMatchEvent(filters, event));
-					// First pass: find the latest event for each replaceable key
-					const latestReplaceableByKey = new Map<string, Event>();
-					const latestParameterizedByKey = new Map<string, Event>();
-					matchedEvents.forEach((event: Event) => {
-						const kindType = getEventKindType(event.kind);
-
-						if (kindType === EventKindType.replaceable) {
-							const key = `${event.pubkey}:${event.kind}`;
-							const existing = latestReplaceableByKey.get(key);
-							if (!existing || event.created_at > existing.created_at) {
-								latestReplaceableByKey.set(key, event);
-							}
-						} else if (kindType === EventKindType.parameterized_replaceable) {
-							const dTag = event.tags.find((t) => t[0] === "d")?.[1];
-							const key = `${event.pubkey}:${event.kind}:${dTag}`;
-							const existing = latestParameterizedByKey.get(key);
-							if (!existing || event.created_at > existing.created_at) {
-								latestParameterizedByKey.set(key, event);
-							}
-						}
-					});
-					// Second pass: filter keeping original order
-					const filteredReplaceableEvents = matchedEvents.filter((event: Event) => {
-						const kindType = getEventKindType(event.kind);
-
-						if (kindType === EventKindType.replaceable) {
-							const key = `${event.pubkey}:${event.kind}`;
-							return latestReplaceableByKey.get(key) === event;
-						} else if (kindType === EventKindType.parameterized_replaceable) {
-							const dTag = event.tags.find((t) => t[0] === "d")?.[1];
-							const key = `${event.pubkey}:${event.kind}:${dTag}`;
-							return latestParameterizedByKey.get(key) === event;
-						}
-
-						return true; // standard events always included
-					});
-
-					for (let i = 0; i < Math.min(filteredReplaceableEvents.length, filters.limit ?? filteredReplaceableEvents.length); i++) {
-						const event = filteredReplaceableEvents[i];
-						console.log(`Sending event to client: ${id}`, event);
-						ws.send(JSON.stringify(["EVENT", id, event]));
+					const rawFilters = messageObject[2] ?? {};
+					if (typeof id !== "string" || rawFilters === null || typeof rawFilters !== "object" || Array.isArray(rawFilters)) {
+						sendNotice(ws, "invalid: REQ must include a subscription id and filter object");
+						break;
 					}
 
-					// EOSE should be sent once all initial events have been sent (either by limit being reached, or no more events matching the filters)
-					// https://github.com/nostr-protocol/nips/discussions/906#discussioncomment-7719394
-					ws.send(JSON.stringify(["EOSE", id]));
+					const normalizedLimit = normalizeSubscriptionLimit(rawFilters.limit, resourceLimits);
+					const filters: FiltersObject = {
+						...rawFilters,
+						"limit": normalizedLimit.limit
+					};
+					if (normalizedLimit.notice) {
+						sendNotice(ws, `${normalizedLimit.notice} for subscription ${id}`);
+					}
 
-					console.log(`Received subscription request: ${id}`, filters);
+					const activeSubscriptions = subscriptions[uuid] ?? [];
+					const existingSubscriptionIndex = activeSubscriptions.findIndex((subscription) => subscription.id === id);
+					if (existingSubscriptionIndex === -1 && activeSubscriptions.length >= resourceLimits.maxSubscriptionsPerConnection) {
+						sendNotice(ws, `too many subscriptions; max is ${resourceLimits.maxSubscriptionsPerConnection}`);
+						console.warn("Rejected subscription request", {
+							"uuid": uuid,
+							"ip": ip,
+							"subscriptionId": id,
+							"activeSubscriptions": activeSubscriptions.length
+						});
+						break;
+					}
+
+					if (existingSubscriptionIndex === -1) {
+						activeSubscriptions.push({
+							"id": id,
+							"filters": filters
+						});
+					} else {
+						activeSubscriptions[existingSubscriptionIndex] = {
+							"id": id,
+							"filters": filters
+						};
+					}
+					subscriptions[uuid] = activeSubscriptions;
+
+					const startedAt = Date.now();
+					let eventCount = 0;
+					try {
+						eventCount = await dataProvider.events.query(filters, { "limit": filters.limit ?? resourceLimits.defaultSubscriptionLimit }, (event: Event) => {
+							if (ws.readyState === WebSocket.OPEN) {
+								ws.send(JSON.stringify(["EVENT", id, event]));
+							}
+						});
+
+						// EOSE is sent once all initial bounded events have been sent.
+						if (ws.readyState === WebSocket.OPEN) {
+							ws.send(JSON.stringify(["EOSE", id]));
+						}
+					} catch (error) {
+						sendNotice(ws, "error: failed to process subscription");
+						console.error("Failed to process subscription request", {
+							"uuid": uuid,
+							"ip": ip,
+							"subscriptionId": id,
+							"error": error
+						});
+						break;
+					}
+
+					console.log("Processed subscription request", {
+						"uuid": uuid,
+						"ip": ip,
+						"subscriptionId": id,
+						"limit": filters.limit,
+						"filterKeys": Object.keys(filters).filter((key) => key !== "limit"),
+						"eventCount": eventCount,
+						"durationMs": Date.now() - startedAt
+					});
 					break;
 				}
 				case "CLOSE": {
@@ -230,21 +348,85 @@ import getEventKindType from "./utils/getEventKindType";
 
 					subscriptions[uuid] = subscriptions[uuid].filter((subscription: Subscription) => subscription.id !== id);
 
-					console.log(`Received subscription close: ${id}`);
+					console.log("Received subscription close", {
+						"uuid": uuid,
+						"ip": ip,
+						"subscriptionId": id
+					});
 					break;
 				}
 				default:
-					console.log(`Unimplemented type: ${type}`);
+					sendNotice(ws, `unsupported message type: ${type}`);
+					console.log("Unimplemented message type", {
+						"uuid": uuid,
+						"ip": ip,
+						"type": type
+					});
 					break;
 			}
 		});
 
 		ws.on("close", () => {
-			delete clients[uuid];
-			delete subscriptions[uuid];
-			console.log(`Client disconnected: ${uuid}`);
+			cleanupClient(uuid);
+			console.log("Client disconnected", {
+				"uuid": uuid,
+				"ip": ip
+			});
+		});
+
+		ws.on("error", (error) => {
+			cleanupClient(uuid);
+			console.error("Client WebSocket error", {
+				"uuid": uuid,
+				"ip": ip,
+				"error": error
+			});
+		});
+
+		ws.on("pong", () => {
+			const client = clients[uuid];
+			if (client) {
+				client.isAlive = true;
+				client.lastActivityAt = Date.now();
+			}
 		});
 	});
+
+	setInterval(() => {
+		const now = Date.now();
+		Object.entries(clients).forEach(([uuid, client]) => {
+			if (client.ws.readyState !== WebSocket.OPEN) {
+				cleanupClient(uuid as ClientId);
+				return;
+			}
+
+			const idleTime = now - client.lastActivityAt;
+			if (idleTime > resourceLimits.idleTimeoutSeconds * 1000) {
+				sendNotice(client.ws, "idle timeout");
+				client.ws.close(1001, "idle timeout");
+				cleanupClient(uuid as ClientId);
+				console.log("Closed idle client", {
+					"uuid": uuid,
+					"ip": client.ip,
+					"idleMs": idleTime
+				});
+				return;
+			}
+
+			if (!client.isAlive) {
+				client.ws.terminate();
+				cleanupClient(uuid as ClientId);
+				console.log("Terminated unresponsive client", {
+					"uuid": uuid,
+					"ip": client.ip
+				});
+				return;
+			}
+
+			client.isAlive = false;
+			client.ws.ping();
+		});
+	}, resourceLimits.pingIntervalSeconds * 1000);
 
 	let isRunningPurgeExpiredEvents = false;
 	setInterval(async () => {
@@ -255,8 +437,10 @@ import getEventKindType from "./utils/getEventKindType";
 		isRunningPurgeExpiredEvents = true;
 		try {
 			console.log("Purging expired events");
-			await dataProvider.events.purgeExpired();
-			console.log("Successfully purged expired events");
+			const purgedEventCount = await dataProvider.events.purgeExpired();
+			console.log("Successfully purged expired events", {
+				"purgedEventCount": purgedEventCount
+			});
 		} catch (error) {
 			console.error(`Failed to purge expired events: `, error);
 		}

--- a/src/business_logic/event/deletion.ts
+++ b/src/business_logic/event/deletion.ts
@@ -6,30 +6,58 @@ import { verifyNostrSignature } from "../../utils/verifySignature";
 import { EventKind } from "../../types/EventKind";
 import insertEvent from "./insert";
 
+/**
+ * Handles NIP-09 deletion events without loading an author's full event history.
+ */
 export default async function (configuration: Configuration, ws: WebSocket, dataProvider: DataProvider, message: Event, sendEventToSubscribers: ((event: Event) => void)): Promise<void> {
-	if (configuration.allowedPublicKeys && configuration.allowedPublicKeys.includes(message.pubkey)) {
-		if (verifyNostrSignature(message)) {
-			const usersEvents: Event[] = (await dataProvider.events.getAll({ authors: [message.pubkey] })).filter((event) => event.pubkey === message.pubkey);
+	const eventMetadata = getEventLogMetadata(message);
 
-			const invalidDeleteIDs = message.tags.some((tag) => tag[0] !== "e" || usersEvents.some((event) => event.id === tag[1] && event.kind !== EventKind.TEXT));
-			if (invalidDeleteIDs) {
-				console.warn(`Received message with invalid delete IDs`, message);
-			}
-
-			await insertEvent(configuration, ws, dataProvider, message, sendEventToSubscribers);
-
-			const deleteIDsToDelete = message.tags.filter((tag) => tag[0] === "e").map((tag) => tag[1]).filter((id) => usersEvents.some((event) => event.id === id));
-			deleteIDsToDelete.forEach((id) => {
-				dataProvider.events.delete(id);
-			});
-		} else {
-			ws.send(JSON.stringify(["OK", message.id, false, "error: invalid signature"]));
-			console.log(`Received message with invalid signature`, message);
-			return;
-		}
-	} else {
+	if (configuration.allowedPublicKeys && !configuration.allowedPublicKeys.includes(message.pubkey)) {
 		ws.send(JSON.stringify(["OK", message.id, false, "blocked: this is currently a private relay"]));
-		console.log(`Received message from unauthorized public key`, message);
-		return
+		console.log("Received message from unauthorized public key", eventMetadata);
+		return;
 	}
+
+	if (!verifyNostrSignature(message)) {
+		ws.send(JSON.stringify(["OK", message.id, false, "error: invalid signature"]));
+		console.log("Received message with invalid signature", eventMetadata);
+		return;
+	}
+
+	const deleteIDs = message.tags
+		.filter((tag) => tag[0] === "e" && typeof tag[1] === "string")
+		.map((tag) => tag[1]);
+	const usersTextEvents: Event[] = await dataProvider.events.getAll({
+		"ids": deleteIDs,
+		"authors": [message.pubkey],
+		"kinds": [EventKind.TEXT]
+	}, { "limit": Math.max(deleteIDs.length, 1) });
+	const deleteIDsToDelete = usersTextEvents.map((event) => event.id);
+	const invalidDeleteIDs = message.tags.some((tag) => tag[0] !== "e") || deleteIDs.length !== deleteIDsToDelete.length;
+	if (invalidDeleteIDs) {
+		console.warn("Received message with invalid delete IDs", {
+			...eventMetadata,
+			"requestedDeleteCount": deleteIDs.length,
+			"matchedDeleteCount": deleteIDsToDelete.length
+		});
+	}
+
+	await insertEvent(configuration, ws, dataProvider, message, sendEventToSubscribers);
+
+	for (const id of deleteIDsToDelete) {
+		await dataProvider.events.delete(id);
+	}
+}
+
+/**
+ * Builds log-safe event metadata without serializing the full event body.
+ */
+function getEventLogMetadata(event: Event): Record<string, string | number> {
+	return {
+		"id": event.id,
+		"kind": event.kind,
+		"pubkey": event.pubkey,
+		"created_at": event.created_at,
+		"tagCount": event.tags.length
+	};
 }

--- a/src/business_logic/event/insert.ts
+++ b/src/business_logic/event/insert.ts
@@ -3,40 +3,56 @@ import { Configuration } from "../../types/Configuration";
 import { WebSocket } from "ws";
 import { verifyNostrSignature } from "../../utils/verifySignature";
 import { DataProvider } from "../../types/DataProvider";
-import getEventKindType from "../../utils/getEventKindType";
-import { EventKindType } from "../../types/EventKind";
 
+/**
+ * Validates, stores, and broadcasts an incoming event.
+ */
 export default async function (configuration: Configuration, ws: WebSocket, dataProvider: DataProvider, message: Event, sendEventToSubscribers: ((event: Event) => void)): Promise<void> {
-	if (configuration.allowedPublicKeys && configuration.allowedPublicKeys.includes(message.pubkey)) {
-		if (verifyNostrSignature(message)) {
-			if (await dataProvider.events.exists(message.id)) {
-				ws.send(JSON.stringify(["OK", message.id, false, "duplicate: event with this id already exists"]));
-				console.warn(`Received message with duplicate id`, message);
-				return;
-			} else {
-				await dataProvider.events.save(message);
-				sendEventToSubscribers(message);
-				ws.send(JSON.stringify(["OK", message.id, true, ""]));
-				console.log(`Received message`, message);
+	const eventMetadata = getEventLogMetadata(message);
 
-				if (configuration.alwaysStoreReplaceableEvents !== true) {
-					if (getEventKindType(message.kind) === EventKindType.replaceable) {
-						const eventsToDelete = (await dataProvider.events.getAll({ kinds: [message.kind], authors: [message.pubkey] })).filter((event: Event) => message.kind === event.kind && message.pubkey === event.pubkey);
-						for (const event of eventsToDelete) {
-							await dataProvider.events.delete(event.id);
-						}
-					}
-				}
-				return;
-			}
-		} else {
-			ws.send(JSON.stringify(["OK", message.id, false, "error: invalid signature"]));
-			console.log(`Received message with invalid signature`, message);
-			return;
-		}
-	} else {
+	if (configuration.allowedPublicKeys && !configuration.allowedPublicKeys.includes(message.pubkey)) {
 		ws.send(JSON.stringify(["OK", message.id, false, "blocked: this is currently a private relay"]));
-		console.log(`Received message from unauthorized public key`, message);
+		console.log("Received message from unauthorized public key", eventMetadata);
 		return;
 	}
+
+	if (!verifyNostrSignature(message)) {
+		ws.send(JSON.stringify(["OK", message.id, false, "error: invalid signature"]));
+		console.log("Received message with invalid signature", eventMetadata);
+		return;
+	}
+
+	if (await dataProvider.events.exists(message.id)) {
+		ws.send(JSON.stringify(["OK", message.id, false, "duplicate: event with this id already exists"]));
+		console.warn("Received message with duplicate id", eventMetadata);
+		return;
+	}
+
+	await dataProvider.events.save(message);
+	let deletedSupersededEvents = 0;
+	if (configuration.alwaysStoreReplaceableEvents !== true) {
+		deletedSupersededEvents = await dataProvider.events.deleteSupersededReplaceableEvents(message);
+	}
+
+	if (await dataProvider.events.exists(message.id)) {
+		sendEventToSubscribers(message);
+	}
+	ws.send(JSON.stringify(["OK", message.id, true, ""]));
+	console.log("Received message", {
+		...eventMetadata,
+		"deletedSupersededEvents": deletedSupersededEvents
+	});
+}
+
+/**
+ * Builds log-safe event metadata without serializing the full event body.
+ */
+function getEventLogMetadata(event: Event): Record<string, string | number> {
+	return {
+		"id": event.id,
+		"kind": event.kind,
+		"pubkey": event.pubkey,
+		"created_at": event.created_at,
+		"tagCount": event.tags.length
+	};
 }

--- a/src/business_logic/event/text.ts
+++ b/src/business_logic/event/text.ts
@@ -6,13 +6,21 @@ import { DataProvider } from "../../types/DataProvider";
 import { durationToString } from "../../utils/durationToString";
 import insertEvent from "./insert";
 
+/**
+ * Validates text-event time bounds before using the shared insert path.
+ */
 export default async function (configuration: Configuration, ws: WebSocket, dataProvider: DataProvider, message: Event, sendEventToSubscribers: ((event: Event) => void)): Promise<void> {
 	if (configuration.eventCreatedAtLimits && configuration.eventCreatedAtLimits.lower && configuration.eventCreatedAtLimits.upper) {
 		const lowerLimit = new Date(Date.now() - (configuration.eventCreatedAtLimits.lower * 1000)).getTime() / 1000;
 		const upperLimit = new Date(Date.now() + (configuration.eventCreatedAtLimits.upper * 1000)).getTime() / 1000;
 		if (message.created_at < lowerLimit || message.created_at > upperLimit) {
 			ws.send(JSON.stringify(["OK", message.id, false, `invalid: the event created_at field is out of the acceptable range (-${durationToString(configuration.eventCreatedAtLimits.lower)}, +${durationToString(configuration.eventCreatedAtLimits.upper)}) for this relay`]));
-			console.log(`Received message with createdAt outside of limits`, message);
+			console.log("Received message with createdAt outside of limits", {
+				"id": message.id,
+				"kind": message.kind,
+				"pubkey": message.pubkey,
+				"created_at": message.created_at
+			});
 			return;
 		}
 	}

--- a/src/data_providers/filesystem.ts
+++ b/src/data_providers/filesystem.ts
@@ -3,10 +3,14 @@ import * as fs from "fs";
 
 import { DataProvider } from "../types/DataProvider";
 import { Event } from "../types/Event";
+import { EventKindType } from "../types/EventKind";
 import { FiltersObject } from "../types/FiltersObject";
+import { filtersMatchEvent } from "../utils/filtersMatchEvent";
+import getEventKindType from "../utils/getEventKindType";
 import isEventExpired from "../utils/isEventExpired";
 
 const dataDirectory = path.join(__dirname, "../../../data");
+const defaultQueryLimit = 1000;
 
 const provider: DataProvider = {
 	"setup": async () => {
@@ -24,19 +28,32 @@ const provider: DataProvider = {
 			}
 			return undefined;
 		},
-		"getAll": async (_filters?: FiltersObject): Promise<Event[]> => {
-			const events: Event[] = [];
-			const eventDirectory = path.join(dataDirectory, "events");
-			const eventFiles = await fs.promises.readdir(eventDirectory);
-			for (const eventFile of eventFiles) {
-				const eventPath = path.join(eventDirectory, eventFile);
-				events.push(JSON.parse(fs.readFileSync(eventPath, "utf8")));
+		"getAll": async (filters?: FiltersObject, options = { "limit": defaultQueryLimit }): Promise<Event[]> => {
+			return getBoundedEvents(await readStoredEvents(), filters, options.limit);
+		},
+		"query": async (filters: FiltersObject | undefined, options, onEvent): Promise<number> => {
+			const matchedEvents = getBoundedEvents(await readStoredEvents(), filters, options.limit);
+			for (const event of matchedEvents) {
+				await onEvent(event);
 			}
-			return events.filter((event) => isEventExpired(event) === false);
+
+			return matchedEvents.length;
 		},
 		"delete": async (id: string): Promise<void> => {
 			const eventPath = path.join(dataDirectory, "events", `${id}.json`);
 			await fs.promises.unlink(eventPath);
+		},
+		"deleteSupersededReplaceableEvents": async (event: Event): Promise<number> => {
+			const storedEvents = await readStoredEvents();
+			const eventsToDelete = storedEvents.filter((storedEvent) => {
+				return !shouldKeepReplaceableEvent(storedEvents, storedEvent, event);
+			});
+
+			for (const eventToDelete of eventsToDelete) {
+				await provider.events.delete(eventToDelete.id);
+			}
+
+			return eventsToDelete.length;
 		},
 		"save": async (event: Event): Promise<void> => {
 			// @TODO: check to see if event already exists
@@ -47,8 +64,8 @@ const provider: DataProvider = {
 			const eventPath = path.join(dataDirectory, "events", `${id}.json`);
 			return fs.existsSync(eventPath);
 		},
-		"purgeExpired": async (): Promise<void> => {
-			const now = Date.now() / 1000;
+		"purgeExpired": async (): Promise<number> => {
+			let deletedEvents = 0;
 			const eventDirectory = path.join(dataDirectory, "events");
 			const eventFiles = await fs.promises.readdir(eventDirectory);
 			for (const eventFile of eventFiles) {
@@ -56,14 +73,107 @@ const provider: DataProvider = {
 				const event: Event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
 				if (isEventExpired(event)) {
 					await fs.promises.unlink(eventPath);
+					deletedEvents++;
 				}
 			}
+			return deletedEvents;
 		}
 	}
 }
 
 export default provider;
 
+/**
+ * Reads all file-backed events for maintenance operations.
+ */
+async function readStoredEvents(): Promise<Event[]> {
+	const events: Event[] = [];
+	const eventDirectory = path.join(dataDirectory, "events");
+	const eventFiles = await fs.promises.readdir(eventDirectory);
+	for (const eventFile of eventFiles) {
+		const eventPath = path.join(eventDirectory, eventFile);
+		events.push(JSON.parse(fs.readFileSync(eventPath, "utf8")));
+	}
+
+	return events;
+}
+
+/**
+ * Applies relay query behavior to the file-backed event list.
+ */
+function getBoundedEvents(sourceEvents: Event[], filters: FiltersObject | undefined, limit: number): Event[] {
+	const matchedEvents = sourceEvents
+		.filter((event) => isEventExpired(event) === false)
+		.filter((event) => filtersMatchEvent(filters as FiltersObject, event))
+		.sort(sortNewestFirst);
+	return removeSupersededReplaceableEvents(matchedEvents).slice(0, limit);
+}
+
+/**
+ * Keeps only the latest replaceable event for each replaceable key.
+ */
+function removeSupersededReplaceableEvents(sourceEvents: Event[]): Event[] {
+	return sourceEvents.filter((event) => {
+		return !sourceEvents.some((candidateEvent) => isNewerReplaceableEvent(candidateEvent, event));
+	});
+}
+
+/**
+ * Returns true when the stored event should survive cleanup after a replaceable write.
+ */
+function shouldKeepReplaceableEvent(sourceEvents: Event[], storedEvent: Event, changedEvent: Event): boolean {
+	if (!isSameReplaceableKey(storedEvent, changedEvent)) {
+		return true;
+	}
+
+	return !sourceEvents.some((candidateEvent) => isNewerReplaceableEvent(candidateEvent, storedEvent));
+}
+
+/**
+ * Returns true when candidateEvent supersedes currentEvent for the same replaceable key.
+ */
+function isNewerReplaceableEvent(candidateEvent: Event, currentEvent: Event): boolean {
+	return isSameReplaceableKey(candidateEvent, currentEvent) && sortNewestFirst(candidateEvent, currentEvent) < 0;
+}
+
+/**
+ * Returns true when two events share a replaceable storage key.
+ */
+function isSameReplaceableKey(firstEvent: Event, secondEvent: Event): boolean {
+	const firstKindType = getEventKindType(firstEvent.kind);
+	if (firstKindType !== getEventKindType(secondEvent.kind)) {
+		return false;
+	}
+	if (firstEvent.pubkey !== secondEvent.pubkey || firstEvent.kind !== secondEvent.kind) {
+		return false;
+	}
+	if (firstKindType === EventKindType.replaceable) {
+		return true;
+	}
+	if (firstKindType === EventKindType.parameterized_replaceable) {
+		return getDTagValue(firstEvent) === getDTagValue(secondEvent);
+	}
+
+	return false;
+}
+
+/**
+ * Sorts events in the same order used by SQLite subscription queries.
+ */
+function sortNewestFirst(firstEvent: Event, secondEvent: Event): number {
+	if (firstEvent.created_at !== secondEvent.created_at) {
+		return secondEvent.created_at - firstEvent.created_at;
+	}
+
+	return secondEvent.id.localeCompare(firstEvent.id);
+}
+
+/**
+ * Returns the first `d` tag value used by parameterized replaceable events.
+ */
+function getDTagValue(event: Event): string {
+	return event.tags.find((tag) => tag[0] === "d")?.[1] ?? "";
+}
 
 async function createDirectoryIfNotExists(dir: string): Promise<void> {
 	if (!fs.existsSync(dir)) {

--- a/src/data_providers/inmemory.ts
+++ b/src/data_providers/inmemory.ts
@@ -1,10 +1,13 @@
 import { DataProvider } from "../types/DataProvider";
 import { Event } from "../types/Event";
+import { EventKindType } from "../types/EventKind";
 import { FiltersObject } from "../types/FiltersObject";
+import { filtersMatchEvent } from "../utils/filtersMatchEvent";
+import getEventKindType from "../utils/getEventKindType";
 import isEventExpired from "../utils/isEventExpired";
 
 let events: Event[] = [];
-let allowedPublicKeys: string[] = [];
+const defaultQueryLimit = 1000;
 
 const provider: DataProvider = {
 	"setup": async () => {},
@@ -16,11 +19,24 @@ const provider: DataProvider = {
 			}
 			return undefined;
 		},
-		"getAll": async (_filters?: FiltersObject): Promise<Event[]> => {
-			return events.filter((event) => isEventExpired(event) === false);
+		"getAll": async (filters?: FiltersObject, options = { "limit": defaultQueryLimit }): Promise<Event[]> => {
+			return getBoundedEvents(events, filters, options.limit);
+		},
+		"query": async (filters: FiltersObject | undefined, options, onEvent): Promise<number> => {
+			const matchedEvents = getBoundedEvents(events, filters, options.limit);
+			for (const event of matchedEvents) {
+				await onEvent(event);
+			}
+
+			return matchedEvents.length;
 		},
 		"delete": async (id: string): Promise<void> => {
 			events = events.filter((event) => event.id !== id);
+		},
+		"deleteSupersededReplaceableEvents": async (event: Event): Promise<number> => {
+			const initialCount = events.length;
+			events = events.filter((storedEvent) => shouldKeepReplaceableEvent(storedEvent, event));
+			return initialCount - events.length;
 		},
 		"save": async (event: Event): Promise<void> => {
 			events.push(event);
@@ -28,10 +44,89 @@ const provider: DataProvider = {
 		"exists": async (id: string): Promise<boolean> => {
 			return events.some((event) => event.id === id);
 		},
-		"purgeExpired": async (): Promise<void> => {
+		"purgeExpired": async (): Promise<number> => {
+			const initialCount = events.length;
 			events = events.filter((event) => isEventExpired(event) === false);
+			return initialCount - events.length;
 		}
 	}
+}
+
+/**
+ * Applies relay query behavior to the already in-memory event list.
+ */
+function getBoundedEvents(sourceEvents: Event[], filters: FiltersObject | undefined, limit: number): Event[] {
+	const matchedEvents = sourceEvents
+		.filter((event) => isEventExpired(event) === false)
+		.filter((event) => filtersMatchEvent(filters as FiltersObject, event))
+		.sort(sortNewestFirst);
+	return removeSupersededReplaceableEvents(matchedEvents).slice(0, limit);
+}
+
+/**
+ * Keeps only the latest replaceable event for each replaceable key.
+ */
+function removeSupersededReplaceableEvents(sourceEvents: Event[]): Event[] {
+	return sourceEvents.filter((event) => {
+		return !sourceEvents.some((candidateEvent) => isNewerReplaceableEvent(candidateEvent, event));
+	});
+}
+
+/**
+ * Returns true when the stored event should survive cleanup after a replaceable write.
+ */
+function shouldKeepReplaceableEvent(storedEvent: Event, changedEvent: Event): boolean {
+	if (!isSameReplaceableKey(storedEvent, changedEvent)) {
+		return true;
+	}
+
+	return !events.some((candidateEvent) => isNewerReplaceableEvent(candidateEvent, storedEvent));
+}
+
+/**
+ * Returns true when candidateEvent supersedes currentEvent for the same replaceable key.
+ */
+function isNewerReplaceableEvent(candidateEvent: Event, currentEvent: Event): boolean {
+	return isSameReplaceableKey(candidateEvent, currentEvent) && sortNewestFirst(candidateEvent, currentEvent) < 0;
+}
+
+/**
+ * Returns true when two events share a replaceable storage key.
+ */
+function isSameReplaceableKey(firstEvent: Event, secondEvent: Event): boolean {
+	const firstKindType = getEventKindType(firstEvent.kind);
+	if (firstKindType !== getEventKindType(secondEvent.kind)) {
+		return false;
+	}
+	if (firstEvent.pubkey !== secondEvent.pubkey || firstEvent.kind !== secondEvent.kind) {
+		return false;
+	}
+	if (firstKindType === EventKindType.replaceable) {
+		return true;
+	}
+	if (firstKindType === EventKindType.parameterized_replaceable) {
+		return getDTagValue(firstEvent) === getDTagValue(secondEvent);
+	}
+
+	return false;
+}
+
+/**
+ * Sorts events in the same order used by SQLite subscription queries.
+ */
+function sortNewestFirst(firstEvent: Event, secondEvent: Event): number {
+	if (firstEvent.created_at !== secondEvent.created_at) {
+		return secondEvent.created_at - firstEvent.created_at;
+	}
+
+	return secondEvent.id.localeCompare(firstEvent.id);
+}
+
+/**
+ * Returns the first `d` tag value used by parameterized replaceable events.
+ */
+function getDTagValue(event: Event): string {
+	return event.tags.find((tag) => tag[0] === "d")?.[1] ?? "";
 }
 
 export default provider;

--- a/src/data_providers/sqlite/index.test.ts
+++ b/src/data_providers/sqlite/index.test.ts
@@ -1,0 +1,228 @@
+import { DataProvider } from "../../types/DataProvider";
+import { Event } from "../../types/Event";
+
+jest.setTimeout(60000);
+
+let provider: DataProvider;
+const baseCreatedAt = 1_700_000_000;
+const bulkEventCount = 20000;
+
+beforeAll(async () => {
+	process.env.NOSTR_RELAY_SQLITE_PATH = ":memory:";
+	provider = (await import("./index")).default;
+	await provider.setup();
+	await seedBulkEvents();
+	await seedTargetedEvents();
+});
+
+afterAll(async () => {
+	await provider.teardown?.();
+	delete process.env.NOSTR_RELAY_SQLITE_PATH;
+});
+
+test("broad queries stay bounded by the storage limit", async () => {
+	let eventCount = 0;
+	const beforeHeap = process.memoryUsage().heapUsed;
+
+	const returnedRows = await provider.events.query({}, { "limit": 25 }, () => {
+		eventCount++;
+	});
+
+	const afterHeap = process.memoryUsage().heapUsed;
+	expect(returnedRows).toBe(25);
+	expect(eventCount).toBe(25);
+	expect(afterHeap - beforeHeap).toBeLessThan(64 * 1024 * 1024);
+});
+
+test("getAll does not return the whole database for an empty filter", async () => {
+	const events = await provider.events.getAll({}, { "limit": 10 });
+
+	expect(events).toHaveLength(10);
+});
+
+test("empty list filters match no events instead of broadening the query", async () => {
+	const events = await provider.events.getAll({ "ids": [] }, { "limit": 10 });
+
+	expect(events).toHaveLength(0);
+});
+
+test("SQL filters by ids authors kinds time and tags", async () => {
+	const events = await provider.events.getAll({
+		"ids": [fixedId("a1")],
+		"authors": ["target-author"],
+		"kinds": [1],
+		"since": baseCreatedAt + bulkEventCount,
+		"until": baseCreatedAt + bulkEventCount + 10,
+		"#p": ["target-pubkey"],
+		"#e": ["target-event"]
+	}, { "limit": 10 });
+
+	expect(events.map((event) => event.id)).toEqual([fixedId("a1")]);
+});
+
+test("expired events are excluded from queries and purged without loading rows", async () => {
+	const expiredEvent = createEvent(90001, {
+		"id": fixedId("ee"),
+		"pubkey": "expired-author",
+		"created_at": baseCreatedAt + 90001,
+		"tags": [["expiration", String(Math.floor(Date.now() / 1000) - 60)]]
+	});
+	await provider.events.save(expiredEvent);
+
+	const queryResults = await provider.events.getAll({ "ids": [expiredEvent.id] }, { "limit": 10 });
+	const purgedCount = await provider.events.purgeExpired();
+
+	expect(queryResults).toHaveLength(0);
+	expect(purgedCount).toBeGreaterThanOrEqual(1);
+	expect(await provider.events.exists(expiredEvent.id)).toBe(false);
+});
+
+test("replaceable event queries return only the latest row per key", async () => {
+	const events = await provider.events.getAll({
+		"authors": ["replaceable-author"],
+		"kinds": [0]
+	}, { "limit": 10 });
+
+	expect(events.map((event) => event.id)).toEqual([fixedId("b2")]);
+});
+
+test("expired replaceable events do not hide the latest active row", async () => {
+	await provider.events.save(createEvent(92001, {
+		"id": fixedId("er1"),
+		"pubkey": "expired-replaceable-author",
+		"created_at": baseCreatedAt + 92001,
+		"kind": 0
+	}));
+	await provider.events.save(createEvent(92002, {
+		"id": fixedId("er2"),
+		"pubkey": "expired-replaceable-author",
+		"created_at": baseCreatedAt + 92002,
+		"kind": 0,
+		"tags": [["expiration", String(Math.floor(Date.now() / 1000) - 60)]]
+	}));
+
+	const events = await provider.events.getAll({
+		"authors": ["expired-replaceable-author"],
+		"kinds": [0]
+	}, { "limit": 10 });
+
+	expect(events.map((event) => event.id)).toEqual([fixedId("er1")]);
+});
+
+test("parameterized replaceable queries return only the latest row per d tag", async () => {
+	const events = await provider.events.getAll({
+		"authors": ["parameterized-author"],
+		"kinds": [30000]
+	}, { "limit": 10 });
+
+	expect(events.map((event) => event.id)).toEqual([fixedId("c3"), fixedId("c2")]);
+});
+
+test("replaceable cleanup deletes superseded stored rows", async () => {
+	const newerEvent = createEvent(91002, {
+		"id": fixedId("d2"),
+		"pubkey": "cleanup-author",
+		"created_at": baseCreatedAt + 91002,
+		"kind": 0
+	});
+	await provider.events.save(createEvent(91001, {
+		"id": fixedId("d1"),
+		"pubkey": "cleanup-author",
+		"created_at": baseCreatedAt + 91001,
+		"kind": 0
+	}));
+	await provider.events.save(newerEvent);
+
+	const deletedCount = await provider.events.deleteSupersededReplaceableEvents(newerEvent);
+
+	expect(deletedCount).toBe(1);
+	expect(await provider.events.exists(fixedId("d1"))).toBe(false);
+	expect(await provider.events.exists(fixedId("d2"))).toBe(true);
+});
+
+/**
+ * Seeds enough events to catch accidental full-result materialization.
+ */
+async function seedBulkEvents(): Promise<void> {
+	for (let index = 0; index < bulkEventCount; index++) {
+		await provider.events.save(createEvent(index));
+	}
+}
+
+/**
+ * Seeds targeted rows used by SQL-side filter and replaceable-event tests.
+ */
+async function seedTargetedEvents(): Promise<void> {
+	await provider.events.save(createEvent(bulkEventCount + 1, {
+		"id": fixedId("a1"),
+		"pubkey": "target-author",
+		"created_at": baseCreatedAt + bulkEventCount + 1,
+		"tags": [
+			["p", "target-pubkey"],
+			["e", "target-event"],
+			["t", "sqlite"]
+		]
+	}));
+	await provider.events.save(createEvent(bulkEventCount + 2, {
+		"id": fixedId("a2"),
+		"pubkey": "target-author",
+		"created_at": baseCreatedAt + bulkEventCount + 2,
+		"tags": [["p", "other-pubkey"]]
+	}));
+	await provider.events.save(createEvent(bulkEventCount + 3, {
+		"id": fixedId("b1"),
+		"pubkey": "replaceable-author",
+		"created_at": baseCreatedAt + bulkEventCount + 3,
+		"kind": 0
+	}));
+	await provider.events.save(createEvent(bulkEventCount + 4, {
+		"id": fixedId("b2"),
+		"pubkey": "replaceable-author",
+		"created_at": baseCreatedAt + bulkEventCount + 4,
+		"kind": 0
+	}));
+	await provider.events.save(createEvent(bulkEventCount + 5, {
+		"id": fixedId("c1"),
+		"pubkey": "parameterized-author",
+		"created_at": baseCreatedAt + bulkEventCount + 5,
+		"kind": 30000,
+		"tags": [["d", "one"]]
+	}));
+	await provider.events.save(createEvent(bulkEventCount + 6, {
+		"id": fixedId("c2"),
+		"pubkey": "parameterized-author",
+		"created_at": baseCreatedAt + bulkEventCount + 6,
+		"kind": 30000,
+		"tags": [["d", "one"]]
+	}));
+	await provider.events.save(createEvent(bulkEventCount + 7, {
+		"id": fixedId("c3"),
+		"pubkey": "parameterized-author",
+		"created_at": baseCreatedAt + bulkEventCount + 7,
+		"kind": 30000,
+		"tags": [["d", "two"]]
+	}));
+}
+
+/**
+ * Builds a deterministic event with safe defaults for storage tests.
+ */
+function createEvent(index: number, overrides: Partial<Event> = {}): Event {
+	return {
+		"id": fixedId(`bulk-${index}`),
+		"pubkey": `author-${index % 25}`,
+		"created_at": baseCreatedAt + index,
+		"kind": 1,
+		"tags": [],
+		"content": `event-${index}`,
+		"sig": `sig-${index}`,
+		...overrides
+	};
+}
+
+/**
+ * Creates SQLite-friendly deterministic ids with stable lexical ordering.
+ */
+function fixedId(suffix: string): string {
+	return suffix.padStart(64, "0");
+}

--- a/src/data_providers/sqlite/index.ts
+++ b/src/data_providers/sqlite/index.ts
@@ -1,98 +1,445 @@
+import * as fs from "fs";
 import * as path from "path";
 import * as sqlite from "sqlite";
 import { Database, Statement } from "sqlite3";
 
 import { DataProvider } from "../../types/DataProvider";
 import { Event } from "../../types/Event";
+import { EventKindType } from "../../types/EventKind";
 import { FiltersObject } from "../../types/FiltersObject";
-import { filtersMatchEvent } from "../../utils/filtersMatchEvent";
-import isEventExpired from "../../utils/isEventExpired";
+import getEventKindType from "../../utils/getEventKindType";
 
 let db: sqlite.Database<Database, Statement>;
+const defaultQueryLimit = 1000;
+const eventColumns = "id, pubkey, created_at, kind, tags, content, sig";
+const aliasedEventColumns = "e.id, e.pubkey, e.created_at, e.kind, e.tags, e.content, e.sig";
+
+interface SqlQuery {
+	"sql": string;
+	"params": any[];
+}
+
+interface SqlWhereClauses {
+	"whereClauses": string[];
+	"params": any[];
+}
 
 const provider: DataProvider = {
 	"setup": async () => {
 		try {
+			const databasePath = getDatabasePath();
+			if (databasePath !== ":memory:") {
+				await fs.promises.mkdir(path.dirname(databasePath), { "recursive": true });
+			}
 			db = await sqlite.open({
-				"filename": path.join(__dirname, "../../../../data.db"),
+				"filename": databasePath,
 				"driver": Database
 			});
+			await db.run("PRAGMA foreign_keys = ON");
 			await db.migrate({
-				"migrationsPath": path.join(__dirname, "../../../../resources/data_providers/sqlite/migrations")
+				"migrationsPath": getMigrationsPath()
 			});
 		} catch (e) {
 			console.error(e);
 			throw e;
 		}
 	},
+	"teardown": async () => {
+		await db.close();
+	},
 	"events": {
 		"get": async (id: string): Promise<Event | undefined> => {
-			const event: Event | undefined = convertFromSqlite(await db.get("SELECT * FROM Event WHERE id = ?", id));
-			if (event && isEventExpired(event) === false) {
-				return event;
-			}
-			return undefined;
+			const event = await db.get(`SELECT ${eventColumns} FROM Event e WHERE e.id = ? AND ${activeEventWhereClause("e")} LIMIT 1`, id, getCurrentUnixTime());
+			return convertFromSqlite(event);
 		},
-		"getAll": async (filters?: FiltersObject): Promise<Event[]> => {
-			const whereClauses: string[] = [];
-			const params: any[] = [];
-
-			if (filters) {
-				if (filters.ids && filters.ids.length > 0) {
-					whereClauses.push(`id IN (${filters.ids.map(() => "?").join(", ")})`);
-					params.push(...filters.ids);
-				}
-				if (filters.authors && filters.authors.length > 0) {
-					whereClauses.push(`pubkey IN (${filters.authors.map(() => "?").join(", ")})`);
-					params.push(...filters.authors);
-				}
-				if (filters.kinds && filters.kinds.length > 0) {
-					whereClauses.push(`kind IN (${filters.kinds.map(() => "?").join(", ")})`);
-					params.push(...filters.kinds);
-				}
-				if (filters.since !== undefined) {
-					whereClauses.push(`created_at >= ?`);
-					params.push(filters.since);
-				}
-				if (filters.until !== undefined) {
-					whereClauses.push(`created_at <= ?`);
-					params.push(filters.until);
-				}
-			}
-
-			let sql = "SELECT * FROM Event";
-			if (whereClauses.length > 0) {
-				sql += " WHERE " + whereClauses.join(" AND ");
-			}
-
-			let events: Event[] = (await db.all(sql, ...params)).map((event) => convertFromSqlite(event));
-			events = events.filter((event) => isEventExpired(event) === false);
-
-			// Apply tag filters in-memory (tags are stored as JSON)
-			if (filters) {
-				events = events.filter((event) => filtersMatchEvent(filters, event));
-			}
-
+		"getAll": async (filters?: FiltersObject, options = { "limit": defaultQueryLimit }): Promise<Event[]> => {
+			const events: Event[] = [];
+			await provider.events.query(filters, options, (event) => {
+				events.push(event);
+			});
 			return events;
 		},
+		"query": async (filters: FiltersObject | undefined, options, onEvent): Promise<number> => {
+			const query = buildSubscriptionQuery(filters, options.limit);
+			const handlerPromises: Promise<void>[] = [];
+			let handlerError: unknown;
+
+			const rowCount = await db.each(query.sql, ...query.params, (error: any, row: any) => {
+				if (error) {
+					handlerError = error;
+					return;
+				}
+				if (handlerError) {
+					return;
+				}
+
+				try {
+					const event = convertFromSqlite(row);
+					const handlerResult = onEvent(event);
+					if (handlerResult instanceof Promise) {
+						handlerPromises.push(handlerResult);
+					}
+				} catch (error) {
+					handlerError = error;
+				}
+			});
+
+			await Promise.all(handlerPromises);
+			if (handlerError) {
+				throw handlerError;
+			}
+
+			return rowCount;
+		},
 		"delete": async (id: string): Promise<void> => {
+			await db.run("DELETE FROM EventTag WHERE event_id = ?", id);
 			await db.run("DELETE FROM Event WHERE id = ?", id);
 		},
+		"deleteSupersededReplaceableEvents": async (event: Event): Promise<number> => {
+			const kindType = getEventKindType(event.kind);
+			if (kindType === EventKindType.replaceable) {
+				const result = await db.run(`
+					DELETE FROM Event
+					WHERE id IN (
+						SELECT old.id
+						FROM Event old
+						WHERE old.pubkey = ?
+							AND old.kind = ?
+							AND EXISTS (
+								SELECT 1
+								FROM Event newer
+								WHERE newer.pubkey = old.pubkey
+									AND newer.kind = old.kind
+									AND ${activeEventWhereClause("newer")}
+									AND ${newerEventWhereClause("newer", "old")}
+							)
+					)
+				`, event.pubkey, event.kind, getCurrentUnixTime());
+				return result.changes ?? 0;
+			}
+
+			if (kindType === EventKindType.parameterized_replaceable) {
+				const result = await db.run(`
+					DELETE FROM Event
+					WHERE id IN (
+						SELECT old.id
+						FROM Event old
+						WHERE old.pubkey = ?
+							AND old.kind = ?
+							AND COALESCE((${firstDTagValueSql("old")}), '') = ?
+							AND EXISTS (
+								SELECT 1
+								FROM Event newer
+								WHERE newer.pubkey = old.pubkey
+									AND newer.kind = old.kind
+									AND COALESCE((${firstDTagValueSql("newer")}), '') = COALESCE((${firstDTagValueSql("old")}), '')
+									AND ${activeEventWhereClause("newer")}
+									AND ${newerEventWhereClause("newer", "old")}
+							)
+					)
+				`, event.pubkey, event.kind, getDTagValue(event), getCurrentUnixTime());
+				return result.changes ?? 0;
+			}
+
+			return 0;
+		},
 		"save": async (event: Event): Promise<void> => {
-			await db.run("INSERT INTO Event (id, pubkey, created_at, kind, tags, content, sig) VALUES (?, ?, ?, ?, ?, ?, ?)", event.id, event.pubkey, event.created_at, event.kind, JSON.stringify(event.tags), event.content, event.sig);
+			await db.exec("BEGIN IMMEDIATE TRANSACTION");
+			try {
+				await db.run("INSERT INTO Event (id, pubkey, created_at, kind, tags, content, sig) VALUES (?, ?, ?, ?, ?, ?, ?)", event.id, event.pubkey, event.created_at, event.kind, JSON.stringify(event.tags), event.content, event.sig);
+				await saveEventTags(event);
+				await db.exec("COMMIT");
+			} catch (error) {
+				await db.exec("ROLLBACK");
+				throw error;
+			}
 		},
 		"exists": async (id: string): Promise<boolean> => {
-			const count = await db.get("SELECT COUNT(*) AS count FROM Event WHERE id = ?", id);
-			// I'm unsure if this `parseInt` is necessary, but I'm doing it just in case.
-			return parseInt(count.count) > 0;
+			const event = await db.get("SELECT 1 AS found FROM Event WHERE id = ? LIMIT 1", id);
+			return Boolean(event);
 		},
-		"purgeExpired": async (): Promise<void> => {
-			const events: Event[] = (await db.all("SELECT * FROM Event")).map((event) => convertFromSqlite(event));
-			const expiredEvents: Event[] = events.filter((event) => isEventExpired(event));
-			console.log(`Purging ${expiredEvents.length} expired events`);
-			await Promise.all(expiredEvents.map((event) => db.run("DELETE FROM Event WHERE id = ?", event.id)));
+		"purgeExpired": async (): Promise<number> => {
+			const result = await db.run(`
+				DELETE FROM Event
+				WHERE id IN (
+					SELECT e.id
+					FROM Event e
+					WHERE ${expiredEventWhereClause("e")}
+				)
+			`, getCurrentUnixTime());
+			return result.changes ?? 0;
 		}
 	}
+}
+
+/**
+ * Builds a subscription query that is fully bounded and filterable by SQLite.
+ */
+function buildSubscriptionQuery(filters: FiltersObject | undefined, limit: number): SqlQuery {
+	const filterClauses = buildFilterWhereClauses(filters, "e");
+	const whereClauses = [
+		...filterClauses.whereClauses,
+		activeEventWhereClause("e"),
+		latestReplaceableWhereClause("e")
+	];
+	const params = [
+		...filterClauses.params,
+		getCurrentUnixTime(),
+		getCurrentUnixTime(),
+		getCurrentUnixTime(),
+		limit
+	];
+
+	return {
+		"sql": `
+			SELECT ${aliasedEventColumns}
+			FROM Event e
+			WHERE ${whereClauses.join(" AND ")}
+			ORDER BY e.created_at DESC, e.id DESC
+			LIMIT ?
+		`,
+		"params": params
+	};
+}
+
+/**
+ * Converts Nostr filter fields into SQL predicates and bound parameters.
+ */
+function buildFilterWhereClauses(filters: FiltersObject | undefined, eventAlias: string): SqlWhereClauses {
+	const whereClauses: string[] = [];
+	const params: any[] = [];
+
+	if (!filters) {
+		return { whereClauses, params };
+	}
+
+	addListFilter(whereClauses, params, `${eventAlias}.id`, filters.ids);
+	addListFilter(whereClauses, params, `${eventAlias}.pubkey`, filters.authors);
+	addListFilter(whereClauses, params, `${eventAlias}.kind`, filters.kinds);
+
+	if (filters.since !== undefined) {
+		whereClauses.push(`${eventAlias}.created_at >= ?`);
+		params.push(filters.since);
+	}
+	if (filters.until !== undefined) {
+		whereClauses.push(`${eventAlias}.created_at <= ?`);
+		params.push(filters.until);
+	}
+
+	Object.entries(filters)
+		.filter(([key]) => /^#[a-zA-Z]$/gmu.test(key))
+		.forEach(([key, value], index) => {
+			const tagValues = normalizeTagFilterValues(value);
+			if (tagValues.length === 0) {
+				whereClauses.push("0 = 1");
+				return;
+			}
+
+			const tagAlias = `filterTag${index}`;
+			whereClauses.push(`
+				EXISTS (
+					SELECT 1
+					FROM EventTag ${tagAlias}
+					WHERE ${tagAlias}.event_id = ${eventAlias}.id
+						AND ${tagAlias}.name = ?
+						AND ${tagAlias}.value IN (${placeholders(tagValues.length)})
+				)
+			`);
+			params.push(key.slice(1), ...tagValues);
+		});
+
+	return { whereClauses, params };
+}
+
+/**
+ * Adds an IN predicate while treating explicit empty arrays as no matches.
+ */
+function addListFilter(whereClauses: string[], params: any[], column: string, values: any[] | undefined): void {
+	if (values === undefined) {
+		return;
+	}
+	if (values.length === 0) {
+		whereClauses.push("0 = 1");
+		return;
+	}
+
+	whereClauses.push(`${column} IN (${placeholders(values.length)})`);
+	params.push(...values);
+}
+
+/**
+ * Returns a SQL predicate that excludes events with an expired expiration tag.
+ */
+function activeEventWhereClause(eventAlias: string): string {
+	return `NOT (${expiredEventWhereClause(eventAlias)})`;
+}
+
+/**
+ * Returns a SQL predicate that matches events with a numeric expiration in the past.
+ */
+function expiredEventWhereClause(eventAlias: string): string {
+	return `
+		EXISTS (
+			SELECT 1
+			FROM EventTag expirationTag
+			WHERE expirationTag.event_id = ${eventAlias}.id
+				AND expirationTag.name = 'expiration'
+				AND expirationTag.value != ''
+				AND expirationTag.value NOT GLOB '*[^0-9]*'
+				AND CAST(expirationTag.value AS INTEGER) < ?
+		)
+	`;
+}
+
+/**
+ * Returns a SQL predicate that keeps only the latest replaceable events.
+ */
+function latestReplaceableWhereClause(eventAlias: string): string {
+	return `
+		(
+			NOT (${replaceableKindWhereClause(eventAlias)} OR ${parameterizedReplaceableKindWhereClause(eventAlias)})
+			OR (
+				${replaceableKindWhereClause(eventAlias)}
+				AND NOT EXISTS (
+					SELECT 1
+					FROM Event newer
+					WHERE newer.pubkey = ${eventAlias}.pubkey
+						AND newer.kind = ${eventAlias}.kind
+						AND ${activeEventWhereClause("newer")}
+						AND ${newerEventWhereClause("newer", eventAlias)}
+				)
+			)
+			OR (
+				${parameterizedReplaceableKindWhereClause(eventAlias)}
+				AND NOT EXISTS (
+					SELECT 1
+					FROM Event newer
+					WHERE newer.pubkey = ${eventAlias}.pubkey
+						AND newer.kind = ${eventAlias}.kind
+						AND COALESCE((${firstDTagValueSql("newer")}), '') = COALESCE((${firstDTagValueSql(eventAlias)}), '')
+						AND ${activeEventWhereClause("newer")}
+						AND ${newerEventWhereClause("newer", eventAlias)}
+				)
+			)
+		)
+	`;
+}
+
+/**
+ * Returns true in SQL when a row is newer than another row.
+ */
+function newerEventWhereClause(newerAlias: string, olderAlias: string): string {
+	return `(${newerAlias}.created_at > ${olderAlias}.created_at OR (${newerAlias}.created_at = ${olderAlias}.created_at AND ${newerAlias}.id > ${olderAlias}.id))`;
+}
+
+/**
+ * Returns the SQL expression for replaceable event kinds.
+ */
+function replaceableKindWhereClause(eventAlias: string): string {
+	return `(${eventAlias}.kind = 0 OR (${eventAlias}.kind >= 10000 AND ${eventAlias}.kind < 20000))`;
+}
+
+/**
+ * Returns the SQL expression for parameterized replaceable event kinds.
+ */
+function parameterizedReplaceableKindWhereClause(eventAlias: string): string {
+	return `(${eventAlias}.kind >= 30000 AND ${eventAlias}.kind < 40000)`;
+}
+
+/**
+ * Returns a scalar subquery for the first d tag on an event.
+ */
+function firstDTagValueSql(eventAlias: string): string {
+	return `SELECT dTag.value FROM EventTag dTag WHERE dTag.event_id = ${eventAlias}.id AND dTag.name = 'd' ORDER BY dTag.position LIMIT 1`;
+}
+
+/**
+ * Saves queryable tag rows for an event inside the caller's transaction.
+ */
+async function saveEventTags(event: Event): Promise<void> {
+	if (event.tags.length === 0) {
+		return;
+	}
+
+	const insertTagStatement = await db.prepare("INSERT INTO EventTag (event_id, name, value, position) VALUES (?, ?, ?, ?)");
+	try {
+		for (const [position, tag] of event.tags.entries()) {
+			const tagName = tag[0];
+			const tagValue = tag[1];
+			if (typeof tagName !== "string" || typeof tagValue !== "string") {
+				continue;
+			}
+
+			await insertTagStatement.run(event.id, tagName, tagValue, position);
+		}
+	} finally {
+		await insertTagStatement.finalize();
+	}
+}
+
+/**
+ * Normalizes a tag filter into an array of values.
+ */
+function normalizeTagFilterValues(value: unknown): string[] {
+	if (Array.isArray(value)) {
+		return value.filter((tagValue) => typeof tagValue === "string");
+	}
+	if (typeof value === "string") {
+		return [value];
+	}
+
+	return [];
+}
+
+/**
+ * Returns the first d tag value used by parameterized replaceable events.
+ */
+function getDTagValue(event: Event): string {
+	return event.tags.find((tag) => tag[0] === "d")?.[1] ?? "";
+}
+
+/**
+ * Returns the current Unix timestamp in seconds for expiration comparisons.
+ */
+function getCurrentUnixTime(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Builds a comma-separated placeholder list for bound parameters.
+ */
+function placeholders(count: number): string {
+	return new Array(count).fill("?").join(", ");
+}
+
+/**
+ * Locates the project root from either source or compiled output paths.
+ */
+function getProjectRoot(): string {
+	const candidates = [
+		path.join(__dirname, "../../../../"),
+		path.join(__dirname, "../../../")
+	];
+	const projectRoot = candidates.find((candidate) => fs.existsSync(path.join(candidate, "resources/data_providers/sqlite/migrations")));
+	if (!projectRoot) {
+		return path.join(__dirname, "../../../../");
+	}
+
+	return projectRoot;
+}
+
+/**
+ * Returns the configured SQLite database path.
+ */
+function getDatabasePath(): string {
+	return process.env.NOSTR_RELAY_SQLITE_PATH ?? path.join(getProjectRoot(), "data.db");
+}
+
+/**
+ * Returns the migration directory for the active runtime path.
+ */
+function getMigrationsPath(): string {
+	return path.join(getProjectRoot(), "resources/data_providers/sqlite/migrations");
 }
 
 function convertFromSqlite(event: any): Event {

--- a/src/types/Configuration.ts
+++ b/src/types/Configuration.ts
@@ -72,6 +72,39 @@ export interface Configuration {
 	 * If this is set to `false` or `undefined`, the relay will delete replaceable events once they are superseded by another event.
 	 */
 	"alwaysStoreReplaceableEvents"?: boolean;
+	/**
+	 * Resource limits that keep broad subscriptions and idle clients bounded.
+	 */
+	"resourceLimits"?: {
+		/**
+		 * The event limit used when a subscription omits `limit` or sends an invalid value.
+		 */
+		"defaultSubscriptionLimit"?: number;
+		/**
+		 * The largest event limit any subscription may request.
+		 */
+		"maxSubscriptionLimit"?: number;
+		/**
+		 * The maximum active subscriptions allowed for one WebSocket connection.
+		 */
+		"maxSubscriptionsPerConnection"?: number;
+		/**
+		 * The maximum concurrent WebSocket connections allowed from one IP address.
+		 */
+		"maxConnectionsPerIp"?: number;
+		/**
+		 * The largest WebSocket message payload accepted by the relay, in bytes.
+		 */
+		"maxMessageBytes"?: number;
+		/**
+		 * The number of seconds a connection may be idle before it is closed.
+		 */
+		"idleTimeoutSeconds"?: number;
+		/**
+		 * The number of seconds between WebSocket ping checks.
+		 */
+		"pingIntervalSeconds"?: number;
+	};
 }
 
 export type StorageType = "inmemory" | "filesystem" | "sqlite";

--- a/src/types/DataProvider.ts
+++ b/src/types/DataProvider.ts
@@ -1,15 +1,27 @@
 import { Event } from "./Event";
 import { FiltersObject } from "./FiltersObject";
 
+export interface EventQueryOptions {
+	/**
+	 * The maximum number of events storage may return for this query.
+	 */
+	"limit": number;
+}
+
+export type EventQueryHandler = (event: Event) => Promise<void> | void;
+
 export interface DataProvider {
 	"setup": () => Promise<void>;
+	"teardown"?: () => Promise<void>;
 
 	"events": {
 		"get": (id: string) => Promise<Event | undefined>;
-		"getAll": (filters?: FiltersObject) => Promise<Event[]>;
+		"getAll": (filters?: FiltersObject, options?: EventQueryOptions) => Promise<Event[]>;
+		"query": (filters: FiltersObject | undefined, options: EventQueryOptions, onEvent: EventQueryHandler) => Promise<number>;
 		"delete": (id: string) => Promise<void>;
+		"deleteSupersededReplaceableEvents": (event: Event) => Promise<number>;
 		"save": (event: Event) => Promise<void>;
 		"exists": (id: string) => Promise<boolean>;
-		"purgeExpired": () => Promise<void>;
+		"purgeExpired": () => Promise<number>;
 	}
 }

--- a/src/types/Event.ts
+++ b/src/types/Event.ts
@@ -1,11 +1,10 @@
-import { EventKind } from "./EventKind";
 import { Tag } from "./Tag";
 
 export interface Event {
 	"id": string;
 	"pubkey": string;
 	"created_at": number;
-	"kind": EventKind;
+	"kind": number;
 	"tags": Tag[];
 	"content": string;
 	"sig": string;

--- a/src/types/FiltersObject.ts
+++ b/src/types/FiltersObject.ts
@@ -1,3 +1,5 @@
+type TagFilterValue = string | string[];
+
 interface FiltersObjectMain {
 	"ids"?: string[];
 	"authors"?: string[];
@@ -11,5 +13,5 @@ interface FiltersObjectMain {
 }
 
 export type FiltersObject = FiltersObjectMain & {
-	[key: `#${string}`]: string;
+	[key: `#${string}`]: TagFilterValue | undefined;
 };

--- a/src/utils/filtersMatchEvent.ts
+++ b/src/utils/filtersMatchEvent.ts
@@ -9,17 +9,18 @@ export function filtersMatchEvent(filters: FiltersObject, event: Event): boolean
 		return true;
 	}
 
-	const idFilterPass = !filters.ids || filters.ids.includes(event.id);
-	const authorFilterPass = !filters.authors || filters.authors.includes(event.pubkey);
-	const kindFilterPass = !filters.kinds || filters.kinds.includes(event.kind);
+	const idFilterPass = !filters.ids || (filters.ids.length > 0 && filters.ids.includes(event.id));
+	const authorFilterPass = !filters.authors || (filters.authors.length > 0 && filters.authors.includes(event.pubkey));
+	const kindFilterPass = !filters.kinds || (filters.kinds.length > 0 && filters.kinds.includes(event.kind));
 	const sinceFilterPass = !filters.since || filters.since <= event.created_at;
 	const untilFilterPass = !filters.until || filters.until >= event.created_at;
 
 	const tagsMatch = Object.entries(filters).filter(([key]) => /^#[a-zA-Z]$/gmu.test(key)).every(([key, value]) => {
+		const tagValues = Array.isArray(value) ? value : [value];
 		const tag = key.slice(1);
 		const eventTagsThatMatchKey = event.tags.filter((eventTag) => eventTag[0] === tag);
 
-		return eventTagsThatMatchKey.some((eventTag) => eventTag[1] === value);
+		return tagValues.length > 0 && eventTagsThatMatchKey.some((eventTag) => tagValues.includes(eventTag[1]));
 	});
 
 	return Boolean(idFilterPass && authorFilterPass && kindFilterPass && sinceFilterPass && untilFilterPass && tagsMatch);

--- a/src/utils/getEventKindType.ts
+++ b/src/utils/getEventKindType.ts
@@ -1,6 +1,6 @@
 import { EventKind, EventKindType } from "../types/EventKind";
 
-export default function (kind: EventKind): EventKindType {
+export default function (kind: number): EventKindType {
 	if (1000 <= kind && kind < 10000) {
 		return EventKindType.regular;
 	} else if ((10000 <= kind && kind < 20000) || kind === 0/* || kind === 3*/) {

--- a/src/utils/resourceLimits.test.ts
+++ b/src/utils/resourceLimits.test.ts
@@ -1,0 +1,44 @@
+import { Configuration } from "../types/Configuration";
+import { normalizeSubscriptionLimit, resolveResourceLimits } from "./resourceLimits";
+
+const configuration: Configuration = {
+	"storage": {
+		"type": "inmemory"
+	},
+	"resourceLimits": {
+		"defaultSubscriptionLimit": 50,
+		"maxSubscriptionLimit": 100
+	}
+};
+
+/**
+ * Builds the shared resolved limits used by these normalization tests.
+ */
+function getLimits() {
+	return resolveResourceLimits(configuration);
+}
+
+test.each([
+	[undefined, 50],
+	[0, 50],
+	[-1, 50],
+	[101, 100],
+	[25, 25]
+])("normalizeSubscriptionLimit(%p)", (requestedLimit, expectedLimit) => {
+	expect(normalizeSubscriptionLimit(requestedLimit, getLimits()).limit).toBe(expectedLimit);
+});
+
+test("resolveResourceLimits caps the default limit to the configured max", () => {
+	const limits = resolveResourceLimits({
+		"storage": {
+			"type": "inmemory"
+		},
+		"resourceLimits": {
+			"defaultSubscriptionLimit": 200,
+			"maxSubscriptionLimit": 100
+		}
+	});
+
+	expect(limits.defaultSubscriptionLimit).toBe(100);
+	expect(limits.maxSubscriptionLimit).toBe(100);
+});

--- a/src/utils/resourceLimits.ts
+++ b/src/utils/resourceLimits.ts
@@ -1,0 +1,82 @@
+import { Configuration } from "../types/Configuration";
+
+export interface ResolvedResourceLimits {
+	"defaultSubscriptionLimit": number;
+	"maxSubscriptionLimit": number;
+	"maxSubscriptionsPerConnection": number;
+	"maxConnectionsPerIp": number;
+	"maxMessageBytes": number;
+	"idleTimeoutSeconds": number;
+	"pingIntervalSeconds": number;
+}
+
+export interface NormalizedSubscriptionLimit {
+	"limit": number;
+	"notice"?: string;
+}
+
+const DEFAULT_RESOURCE_LIMITS: ResolvedResourceLimits = {
+	"defaultSubscriptionLimit": 500,
+	"maxSubscriptionLimit": 1000,
+	"maxSubscriptionsPerConnection": 32,
+	"maxConnectionsPerIp": 64,
+	"maxMessageBytes": 64 * 1024,
+	"idleTimeoutSeconds": 120,
+	"pingIntervalSeconds": 30
+};
+
+/**
+ * Resolves configured resource limits while preserving safe defaults.
+ */
+export function resolveResourceLimits(configuration: Configuration): ResolvedResourceLimits {
+	const configuredLimits = configuration.resourceLimits ?? {};
+	const maxSubscriptionLimit = positiveIntegerOrDefault(configuredLimits.maxSubscriptionLimit, DEFAULT_RESOURCE_LIMITS.maxSubscriptionLimit);
+	const defaultSubscriptionLimit = Math.min(
+		positiveIntegerOrDefault(configuredLimits.defaultSubscriptionLimit, DEFAULT_RESOURCE_LIMITS.defaultSubscriptionLimit),
+		maxSubscriptionLimit
+	);
+
+	return {
+		"defaultSubscriptionLimit": defaultSubscriptionLimit,
+		"maxSubscriptionLimit": maxSubscriptionLimit,
+		"maxSubscriptionsPerConnection": positiveIntegerOrDefault(configuredLimits.maxSubscriptionsPerConnection, DEFAULT_RESOURCE_LIMITS.maxSubscriptionsPerConnection),
+		"maxConnectionsPerIp": positiveIntegerOrDefault(configuredLimits.maxConnectionsPerIp, DEFAULT_RESOURCE_LIMITS.maxConnectionsPerIp),
+		"maxMessageBytes": positiveIntegerOrDefault(configuredLimits.maxMessageBytes, DEFAULT_RESOURCE_LIMITS.maxMessageBytes),
+		"idleTimeoutSeconds": positiveIntegerOrDefault(configuredLimits.idleTimeoutSeconds, DEFAULT_RESOURCE_LIMITS.idleTimeoutSeconds),
+		"pingIntervalSeconds": positiveIntegerOrDefault(configuredLimits.pingIntervalSeconds, DEFAULT_RESOURCE_LIMITS.pingIntervalSeconds)
+	};
+}
+
+/**
+ * Converts a client-provided subscription limit into a bounded database limit.
+ */
+export function normalizeSubscriptionLimit(limit: unknown, limits: ResolvedResourceLimits): NormalizedSubscriptionLimit {
+	if (!Number.isInteger(limit) || (limit as number) <= 0) {
+		return {
+			"limit": limits.defaultSubscriptionLimit,
+			"notice": `subscription limit was set to ${limits.defaultSubscriptionLimit}`
+		};
+	}
+
+	if ((limit as number) > limits.maxSubscriptionLimit) {
+		return {
+			"limit": limits.maxSubscriptionLimit,
+			"notice": `subscription limit was capped at ${limits.maxSubscriptionLimit}`
+		};
+	}
+
+	return {
+		"limit": limit as number
+	};
+}
+
+/**
+ * Keeps numeric resource settings positive integers.
+ */
+function positiveIntegerOrDefault(value: unknown, defaultValue: number): number {
+	if (!Number.isInteger(value) || (value as number) <= 0) {
+		return defaultValue;
+	}
+
+	return value as number;
+}


### PR DESCRIPTION
## What changed

- Moved SQLite subscription reads to bounded, database-driven queries with explicit columns and SQL-side filtering for ids, authors, kinds, since, until, tags, expiration, and replaceable-event collapse.
- Added an indexed `EventTag` table with migration backfill so tag filters are queryable without materializing full event rows in Node.
- Added configurable resource limits for default/max subscription limits, message size, subscriptions per connection, connections per IP, ping/pong, and idle timeouts.
- Reduced hot-path logging to request and event metadata instead of full event objects.
- Added regression coverage for broad subscriptions, invalid limits, SQL-side filters, expiration, and replaceable events with a 20k-event SQLite seed.

## Why

Broad Nostr subscription requests could previously trigger `SELECT * FROM Event`, load large row sets into Node, and then filter or collapse replaceable events in JavaScript. On larger relay databases, empty filters or `limit: 0` could consume multiple GiB of memory and cause host-wide OOM restarts.

## Impact

Subscription requests are now capped before storage work starts, SQLite handles the heavy filtering/indexed tag lookup, and results are sent through a bounded query callback. Existing inmemory and filesystem providers were updated to follow the same bounded provider contract.

## Validation

- `npm run build`
- `npm test -- --runInBand`
- `git diff --check`
- `rg -n 'SELECT \\*' src resources` returned no matches